### PR TITLE
Add CI build for main and badges to README

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,8 @@ name: Lint and Test
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
 env:
   GOPRIVATE: "github.com/Invisv-Privacy/*"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # An IETF MASQUE implementation in Go
 
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/invisv-privacy/masque)](https://pkg.go.dev/badge/github.com/invisv-privacy/masque)
+![Build Status](https://github.com/invisv-privacy/masque/actions/workflows/build.yaml/badge.svg?branch=main)
+
 ## What is INVISV masque?
 
 INVISV **masque** is an implementation of the [IETF MASQUE](https://datatracker.ietf.org/wg/masque/about/) tunneling protocol, written in Go. INVISV **masque** provides the client-side functionality needed for running a [Multi-Party Relay](https://invisv.com/articles/relay.html) service to protect users' network privacy.


### PR DESCRIPTION
This will start building CI for the `main` branch. We're already doing it on pull requests to `main` so this is mostly so that we can display the build status badge on the README.