### PR TITLE
http2 improvements

### DIFF
--- a/http2/client.go
+++ b/http2/client.go
@@ -137,7 +137,7 @@ func (c *Client) getReadyH2ClientConnOpt(addr string, lowlatency bool) (*gohttp2
 	for i := 0; i < len(c.h2Conns); i++ {
 		cc := c.h2Conns[i]
 		state := cc.State()
-		if state.Closed {
+		if state.Closed || state.Closing {
 			c.h2Conns = append(c.h2Conns[:i], c.h2Conns[i+1:]...)
 			i--
 			continue

--- a/http2/client.go
+++ b/http2/client.go
@@ -351,6 +351,7 @@ func (c *Client) dialProxyViaH2() (*gohttp2.Transport, error) {
 		AllowHTTP:          true,
 		DisableCompression: true,
 		WriteByteTimeout:   time.Second * 3,
+		ReadIdleTimeout:    time.Second * 3,
 	}
 	return tr, nil
 }

--- a/http2/client.go
+++ b/http2/client.go
@@ -352,6 +352,7 @@ func (c *Client) dialProxyViaH2() (*gohttp2.Transport, error) {
 		DisableCompression: true,
 		WriteByteTimeout:   time.Second * 3,
 		ReadIdleTimeout:    time.Second * 3,
+		PingTimeout:        time.Second * 2,
 	}
 	return tr, nil
 }


### PR DESCRIPTION
The 2 core fixes here are:

    Checking for connections in a Closing state as well as Closed
    Adding a ReadIdleTimeout to our http2 transport (see the commit message for more detail on that

The remaining pieces are just a refactor and adding a CreateUDPStream test for our http2 stack.
